### PR TITLE
Fixes module importing issue #1

### DIFF
--- a/basics/module_a.js
+++ b/basics/module_a.js
@@ -1,7 +1,7 @@
-function add (a, b) {
+export function add (a, b) {
     return a + b;
 }
 
-function multiply (a, b) {
+export function multiply (a, b) {
     return a * b;
 }

--- a/basics/package.json
+++ b/basics/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "module"
+}


### PR DESCRIPTION
This pull request includes changes to the `basics` module to support ES module syntax by adding export statements to functions and updating the `package.json` file.

Key changes include:

* [`basics/module_a.js`](diffhunk://#diff-9063bfc12302c13b5748b0067ebd218ae31964167e95666810385c177182119cL1-R5): Added `export` keyword to the `add` and `multiply` functions to enable ES module syntax.
* [`basics/package.json`](diffhunk://#diff-6d988e2140655784be9497698060c199ffd7c5fa7f5f4f1cf5c7710fb3f857acR1-R3): Added a `type` field with the value `module` to specify the module type as ES module.